### PR TITLE
Don't build examples when being included in other projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,4 +48,6 @@ install(EXPORT igraph-cpp-targets
         NAMESPACE igraph::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/igraph-cpp)
 
-add_subdirectory(examples)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    add_subdirectory(examples)
+endif()


### PR DESCRIPTION
This allows **igraph-cpp** to be used via `FetchContent` without adding all of the examples into the downstream build.